### PR TITLE
Escaping nested substitution within comment

### DIFF
--- a/bbr-restore-clusters.html.md.erb
+++ b/bbr-restore-clusters.html.md.erb
@@ -125,7 +125,7 @@ To redeploy a <%= vars.k8s_runtime_abbr %>-provisioned cluster through the <%= v
 Removed under https://www.pivotaltracker.com/story/show/172207907
 But we may choose to restore this if there's interest in describing 
 restoring clusters with a subset of erroands
-* To redeploy a <%%= vars.k8s_runtime_abbr %>-provisioned cluster through the BOSH CLI:
+* To redeploy a <%%= vars.k8s_runtime_abbr %%>-provisioned cluster through the BOSH CLI:
     1. Identify the names of your cluster deployments:
 
         ```

--- a/bbr-restore-clusters.html.md.erb
+++ b/bbr-restore-clusters.html.md.erb
@@ -125,7 +125,7 @@ To redeploy a <%= vars.k8s_runtime_abbr %>-provisioned cluster through the <%= v
 Removed under https://www.pivotaltracker.com/story/show/172207907
 But we may choose to restore this if there's interest in describing 
 restoring clusters with a subset of erroands
-* To redeploy a <%= vars.k8s_runtime_abbr %>-provisioned cluster through the BOSH CLI:
+* To redeploy a <%%= vars.k8s_runtime_abbr %>-provisioned cluster through the BOSH CLI:
     1. Identify the names of your cluster deployments:
 
         ```


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
1.9
1.8
1.7
....

Currently this page https://docs.pivotal.io/tkgi/1-10/bbr-restore-clusters.html does not render correctly.  

![image](https://user-images.githubusercontent.com/5050479/112931444-09170400-90d1-11eb-8eee-9885062f6821.png)

This change should correctly preform the relevant escape to allow the page to be displayed properly
